### PR TITLE
Feature: Use data-uri for SVG icons to allow custom colors (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Buttons (left to right):
   * configure temporary overrides for trigger words to be exempt from decoration (matches begin of word)
 * Custom Styles
   * be aware that existing styles can be overridden
-  * The `gutterIconPath` is not customizable right now. You can only use the images provided with the extension right now: `images/bookmark-{red,green,blue,purple}.svg`. See example below.
+  * `gutterIconPath` may refer to only the four images provided with the extension right now: `images/bookmark-{red,green,blue,purple}.svg`. See example below.
+  * `gutterIconColor` may be used to specify a custom icon color using any RGBA format. gutterIconColor will override gutterIconPath. See example below.
 * Custom word mappings
   * You can assign multiple regex trigger words to a decoration style. See example below.
 
@@ -106,6 +107,7 @@ Buttons (left to right):
     },
     "red": {
         "gutterIconPath": "images/bookmark-red.svg",
+        "gutterIconColor": "#F44336",
         "light": {
             "fontWeight": "bold"
         },
@@ -133,6 +135,16 @@ Buttons (left to right):
     },
     "purple": {
         "gutterIconPath": "images/bookmark-purple.svg",
+        "light": {
+            "fontWeight": "bold"
+        },
+        "dark": {
+            "color": "Chocolate"
+        }
+    },
+    "warn": {   // example custom style with yellow color
+        "gutterIconColor": "#F4F400",
+        "overviewRulerColor": "#F4F400B0",
         "light": {
             "fontWeight": "bold"
         },

--- a/src/features/inlineBookmarks.js
+++ b/src/features/inlineBookmarks.js
@@ -229,7 +229,7 @@ class InlineBookmarksCtrl {
     }
 
     async _decorateWords(editor, words, style, noAdd) {
-        const decoStyle = this.styles[style] || this.styles['default'];
+        const decoStyle = this.styles[style].type || this.styles['default'].type;
 
         let locations = this._findWords(editor.document, words);
         editor.setDecorations(decoStyle, locations);  // set decorations
@@ -311,8 +311,12 @@ class InlineBookmarksCtrl {
         );
     }
 
-    _getDecorationType(color) {
-        return vscode.window.createTextEditorDecorationType({
+    _getDecorationStyle(decoOptions) {
+        return { type: vscode.window.createTextEditorDecorationType(decoOptions), options: decoOptions };
+    }
+
+    _getDecorationDefaultStyle(color) {
+        return this._getDecorationStyle({
             "gutterIconPath": this._getBookmarkDataUri(color),
             "overviewRulerColor": color+"B0",   // this is safe/suitable for the defaults only.  Custom ruler color is handled below.
             "light": {
@@ -330,11 +334,11 @@ class InlineBookmarksCtrl {
         const purple    = '#C679E0';
         const red       = '#F44336';
         let styles      = {
-            "default":  this._getDecorationType(blue),
-            "red":      this._getDecorationType(red),
-            "blue":     this._getDecorationType(blue),
-            "green":    this._getDecorationType(green),
-            "purple":   this._getDecorationType(purple)
+            "default":  this._getDecorationDefaultStyle(blue),
+            "red":      this._getDecorationDefaultStyle(red),
+            "blue":     this._getDecorationDefaultStyle(blue),
+            "green":    this._getDecorationDefaultStyle(green),
+            "purple":   this._getDecorationDefaultStyle(purple)
         };
 
         let customStyles = settings.extensionConfig().expert.custom.styles;
@@ -363,7 +367,7 @@ class InlineBookmarksCtrl {
             if (decoOptions.backgroundColor) {
                 decoOptions.isWholeLine = true;
             }
-            styles[decoId] = vscode.window.createTextEditorDecorationType(decoOptions);
+            styles[decoId] = this._getDecorationStyle(decoOptions);
         }
 
         return styles;
@@ -457,7 +461,7 @@ class InlineBookmarksDataModel {
                             type: NodeType.LOCATION,
                             category: cat,
                             parent: element,
-                            iconPath: vscode.Uri.file(this.controller.context.asAbsolutePath(path.join("images", `bookmark-${cat}.svg`)))
+                            iconPath: this.controller.styles[cat].options.gutterIconPath
                         };
                     });
                 }).flat(1);

--- a/src/features/inlineBookmarks.js
+++ b/src/features/inlineBookmarks.js
@@ -304,58 +304,37 @@ class InlineBookmarksCtrl {
         return { ...defaultWords, ...settings.extensionConfig().expert.custom.words.mapping };
     }
 
+    _getBookmarkDataUri(color) {
+        return vscode.Uri.parse(
+            "data:image/svg+xml," +
+            encodeURIComponent(`<svg version="1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" enable-background="new 0 0 48 48"><path fill="${color}" d="M37,43l-13-6l-13,6V9c0-2.2,1.8-4,4-4h18c2.2,0,4,1.8,4,4V43z"/></svg>`)
+        );
+    }
+
+    _getDecorationType(color) {
+        return vscode.window.createTextEditorDecorationType({
+            "gutterIconPath": this._getBookmarkDataUri(color),
+            "overviewRulerColor": color+"B0",   // this is safe/suitable for the defaults only.  Custom ruler color is handled below.
+            "light": {
+                "fontWeight": "bold"
+            },
+            "dark": {
+                "color": "Chocolate"
+            }
+        })
+    }
+
     _reLoadDecorations() {
-        let styles = {
-            "default": vscode.window.createTextEditorDecorationType({
-                "gutterIconPath": this.context.asAbsolutePath(path.join("images", "bookmark-blue.svg")),
-                "overviewRulerColor": "rgba(21, 126, 251, 0.7)",
-                "light": {
-                    "fontWeight": "bold"
-                },
-                "dark": {
-                    "color": "Chocolate"
-                }
-            }),
-            "red": vscode.window.createTextEditorDecorationType({
-                "gutterIconPath": this.context.asAbsolutePath(path.join("images", "bookmark-red.svg")),
-                "overviewRulerColor": "rgba(244, 67, 54, 0.7)",
-                "light": {
-                    "fontWeight": "bold"
-                },
-                "dark": {
-                    "color": "Chocolate"
-                }
-            }),
-            "blue": vscode.window.createTextEditorDecorationType({
-                "gutterIconPath": this.context.asAbsolutePath(path.join("images", "bookmark-blue.svg")),
-                "overviewRulerColor": "rgba(21, 126, 251, 0.7)",
-                "light": {
-                    "fontWeight": "bold"
-                },
-                "dark": {
-                    "color": "Chocolate"
-                }
-            }),
-            "green": vscode.window.createTextEditorDecorationType({
-                "gutterIconPath": this.context.asAbsolutePath(path.join("images", "bookmark-green.svg")),
-                "overviewRulerColor": "rgba(47, 206, 124, 0.7)",
-                "light": {
-                    "fontWeight": "bold"
-                },
-                "dark": {
-                    "color": "Chocolate"
-                }
-            }),
-            "purple": vscode.window.createTextEditorDecorationType({
-                "gutterIconPath": this.context.asAbsolutePath(path.join("images", "bookmark-purple.svg")),
-                "overviewRulerColor": "rgba(198, 121, 224, 0.7)",
-                "light": {
-                    "fontWeight": "bold"
-                },
-                "dark": {
-                    "color": "Chocolate"
-                }
-            })
+        const blue      = '#157EFB';
+        const green     = '#2FCE7C';
+        const purple    = '#C679E0';
+        const red       = '#F44336';
+        let styles      = {
+            "default":  this._getDecorationType(blue),
+            "red":      this._getDecorationType(red),
+            "blue":     this._getDecorationType(blue),
+            "green":    this._getDecorationType(green),
+            "purple":   this._getDecorationType(purple)
         };
 
         let customStyles = settings.extensionConfig().expert.custom.styles;
@@ -368,8 +347,14 @@ class InlineBookmarksCtrl {
 
             let decoOptions = { ...customStyles[decoId] };
 
-            //fix path
-            decoOptions.gutterIconPath = this.context.asAbsolutePath(decoOptions.gutterIconPath);
+            // default to blue if neither an icon path nor an icon color is specified
+            if (!decoOptions.gutterIconPath) {
+                decoOptions.gutterIconColor = decoOptions.gutterIconColor || blue;
+            }
+
+            //apply icon color if provided, otherwise fix the path
+            decoOptions.gutterIconPath = decoOptions.gutterIconColor ? this._getBookmarkDataUri(decoOptions.gutterIconColor) : this.context.asAbsolutePath(decoOptions.gutterIconPath);
+
             //overview
             if (decoOptions.overviewRulerColor) {
                 decoOptions.overviewRulerLane = vscode.OverviewRulerLane.Full;


### PR DESCRIPTION
Closes #30 
Add gutterIconColor to accept any RGBA color for the icon
Add helper functions to create SVG data-uri and default decorations
Add default blue if no icon path or color is provided

Hi-  I'm really getting a lot of use out of your extension!  Hopefully you'll find these pull requests useful.
Thanks!
