### PR TITLE
control "visible editors" filter behavior

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
-.vscode-test/**
+.vscode-test*/**
+dist/
 .gitignore
 vsc-extension-quickstart.md

--- a/package.json
+++ b/package.json
@@ -233,25 +233,25 @@
                 "inline-bookmarks.default.words.red": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit[ \\t\\r\\n$]",
+                    "default": "@audit[\\s]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `red`."
                 },
                 "inline-bookmarks.default.words.green": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit\\-ok[ \\t\\r\\n$]",
+                    "default": "@audit\\-ok[\\s]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `green`."
                 },
                 "inline-bookmarks.default.words.blue": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit\\-info[ \\t\\r\\n$], @todo[ \\t\\r\\n$], @note[ \\t\\r\\n$], @remind[ \\t\\r\\n$], @follow-up[ \\t\\r\\n$]",
+                    "default": "@audit\\-info[\\s], @todo[\\s], @note[\\s], @remind[\\s], @follow-up[\\s]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `blue`."
                 },
                 "inline-bookmarks.default.words.purple": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit\\-issue[ \\t\\r\\n$]",
+                    "default": "@audit\\-issue[\\s]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `purple`."
                 },
                 "inline-bookmarks.exceptions.words.ignore": {

--- a/package.json
+++ b/package.json
@@ -192,6 +192,16 @@
                     "default": false,
                     "description": "Show bookmarks for visible editors/files only."
                 },
+                "inline-bookmarks.view.showVisibleFilesOnlyMode": {
+                    "category": "view",
+                    "type": "string",
+                    "enum": [
+                        "allVisibleEditors",
+                        "onlyActiveEditor"
+                    ],
+                    "default": "allVisibleEditors",
+                    "description": "Select 'Show Visible editors only' mode. Either show bookmarks for all visible editors or only for the currently selected editor. default: All Visible Editors"
+                },
                 "inline-bookmarks.view.expanded": {
                     "category": "view",
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -233,25 +233,25 @@
                 "inline-bookmarks.default.words.red": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit[ \\t\\n$]",
+                    "default": "@audit[ \\t\\r\\n$]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `red`."
                 },
                 "inline-bookmarks.default.words.green": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit\\-ok[ \\t\\n$]",
+                    "default": "@audit\\-ok[ \\t\\r\\n$]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `green`."
                 },
                 "inline-bookmarks.default.words.blue": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit\\-info[ \\t\\n$], @todo[ \\t\\n$], @note[ \\t\\n$], @remind[ \\t\\n$], @follow-up[ \\t\\n$]",
+                    "default": "@audit\\-info[ \\t\\r\\n$], @todo[ \\t\\r\\n$], @note[ \\t\\r\\n$], @remind[ \\t\\r\\n$], @follow-up[ \\t\\r\\n$]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `blue`."
                 },
                 "inline-bookmarks.default.words.purple": {
                     "category": "trigger words",
                     "type": "string",
-                    "default": "@audit\\-issue[ \\t\\n$]",
+                    "default": "@audit\\-issue[ \\t\\r\\n$]",
                     "markdownDescription": "A comma-separated list of tags/trigger words (regex accepted) to highlight `purple`."
                 },
                 "inline-bookmarks.exceptions.words.ignore": {

--- a/src/features/inlineBookmarks.js
+++ b/src/features/inlineBookmarks.js
@@ -429,7 +429,14 @@ class InlineBookmarksDataModel {
         let fileBookmarks = Object.keys(this.controller.bookmarks);
         
         if (settings.extensionConfig().view.showVisibleFilesOnly) {
-            let visibleEditorUris = vscode.window.visibleTextEditors.map(te => te.document.uri.path);
+
+            let visibleEditorUris;
+            if(settings.extensionConfig().view.showVisibleFilesOnlyMode === "onlyActiveEditor") {
+                visibleEditorUris = [vscode.window.activeTextEditor.document.uri.path];
+            } else {
+                visibleEditorUris = vscode.window.visibleTextEditors.map(te => te.document.uri.path);
+            }
+
             fileBookmarks = fileBookmarks.filter(v => visibleEditorUris.includes(vscode.Uri.parse(v).path));
         }
 


### PR DESCRIPTION
- fixes #47

new config option to define if "visible editors" is (1) all visible editors/files OR (2) only the currently selected/active editor.

default is all visible editors.

```
inline-bookmarks.view.showVisibleFilesOnlyMode":  "allVisibleEditors" || "onlyActiveEditor" || default: "allVisibleEditors" 
```