### PR TITLE
select-bookmark filter only if filter func is set

### DIFF
--- a/src/features/inlineBookmarks.js
+++ b/src/features/inlineBookmarks.js
@@ -33,7 +33,7 @@ class Commands {
             let resource = vscode.Uri.parse(uri).fsPath;
             let fname = path.parse(resource).base;
 
-            if(!filter(resource)){
+            if(filter && !filter(resource)){
                 return;
             }
 


### PR DESCRIPTION
fix `select bookmark` would error with `filter` not set. - fixes #50