### PR TITLE
Remove book emoji from explorer name

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
             "explorer": [
                 {
                     "id": "inlineBookmarksExplorer",
-                    "name": "📘 Inline Bookmarks"
+                    "name": "Inline Bookmarks"
                 }
             ]
         },


### PR DESCRIPTION
In my opinion, the 📘 emoji is a bit out of place visually among other VS Code extensions that add tabs to the file explorer. 😄 

![screenshot_2023-11-20_at_23 19 08@2x](https://github.com/tintinweb/vscode-inline-bookmarks/assets/3588798/5bbd1a57-3d3b-4050-9287-293c711d34a2)